### PR TITLE
IP environtment variable to define public IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ If you want to customize an environment, create a `.env` file replacing the foll
 | WORKERS          | 1                                            |
 | MTPROTO_REPO_URL | https://github.com/TelegramMessenger/MTProxy |
 | TZ               |                                              |
+| IP               | Public IP address (optional)                 |
 
 An alternative to `MTPROTO_REPO_URL` is https://github.com/GetPageSpeed/MTProxy that is a fork from MTProxy with patches applied.
+
+Public IP address is detected using "curl ifconfig.co". If it fails, you can provide it with the IP variable.
 
 To more informations read the follow session.
 

--- a/container-image-root/entrypoint.sh
+++ b/container-image-root/entrypoint.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 set -x
 
+[ "$IP" == "" ] && IP=$(curl ifconfig.co/ip -s)
+
 service ntp start
 cron
 
 if [ "$1" == "" ];
 then
-./mtproto-proxy -u nobody -p 8888 -H 8889 -S $SECRET --aes-pwd proxy-secret proxy-multi.conf -M $WORKERS --nat-info $(hostname --ip-address):$(curl ifconfig.co/ip -s) --http-stats
+./mtproto-proxy -u nobody -p 8888 -H 8889 -S $SECRET --aes-pwd proxy-secret proxy-multi.conf -M $WORKERS --nat-info $(hostname --ip-address):$IP --http-stats
 else
 exec "$1"
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,4 @@ services:
       - SECRET
       - WORKERS
       - MTPROTO_REPO_URL
+      - IP


### PR DESCRIPTION
"curl ifconfig.co" is returning HTML (captcha) when invoked from my VPS.

This patch allows to define an environment variable to set the public IP address.