### PR TITLE
Add CI configuration for docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/docker-image-build-publish.yml
+++ b/.github/workflows/docker-image-build-publish.yml
@@ -1,16 +1,7 @@
-name: Docker
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
+name: CI
 
 on:
   push:
-    branches: [ main ]
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
-  pull_request:
     branches: [ main ]
 
 env:
@@ -19,43 +10,43 @@ env:
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 
-
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
+  docker:
     permissions:
       contents: read
       packages: write
 
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
-      - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push vanilla
+        uses: docker/build-push-action@v6
         with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.actor }}/mtproxy-vanilla:latest
+
+      - name: Build and push GetPageSpeed
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.actor }}/mtproxy-getpagespeed:latest
+          build-args:
+            MTPROTO_REPO_URL=https://github.com/GetPageSpeed/MTProxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt -y update > /dev/null 2>&1;\
     apt install -y gcc-9 g++-9 cpp-9 > /dev/null 2>&1;\
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 --slave /usr/bin/g++ g++ /usr/bin/g++-9 --slave /usr/bin/gcov gcov /usr/bin/gcov-9 > /dev/null 2>&1;\
 # Clone the repo:
-    IP_EXT=$(curl ifconfig.co/ip -s) ;\
+    IP_EXT=$(curl ifconfig.io/ip -s) ;\
     IP_INT=$(hostname --ip-address) ;\
     git clone ${MTPROTO_REPO_URL} /srv/MTProxy > /dev/null 2>&1 ;\
 # To build, simply run make, the binary will be in objs/bin/mtproto-proxy:

--- a/container-image-root/entrypoint.sh
+++ b/container-image-root/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-[ "$IP" == "" ] && IP=$(curl ifconfig.co/ip -s)
+[ "$IP" == "" ] && IP=$(curl ifconfig.io/ip -s)
 
 service ntp start
 cron


### PR DESCRIPTION
Hi, with new restrictions on Telegram calls it is more interesting to add docker images for easier deployment. Original mtproxy doesn't allow to make calls but GetPageSpeed is working great. So I added CI configuration for building vanilla and GetPageSpeed versions, add dependabot, and replace ifconfig.co with ifconfig.io because .co is not reliable (at least for me). 
